### PR TITLE
Adonis-Cli Requires NPM Even When --yarn Flag Is On FIX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: node_js
 node_js:
   - "7"
+before_script:
+  - npm install -g yarn mocha
+  - npm install
 scripts:
+  - node --version
+  - npm --version
+  - yarn -V
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - "7"
+scripts:
+  - npm test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+# Test against the latest version of this Node.js version
+environment:
+  nodejs_version: "7"
+
+# Install scripts. (runs after repo cloning)
+install:
+  # Get the latest stable version of Node.js or io.js
+  - ps: Install-Product node $env:nodejs_version
+  # install modules
+  - npm install
+
+# Post-install test scripts.
+test_script:
+  # Output useful info for debugging.
+  - node --version
+  - npm --version
+  # run tests
+  - npm test
+
+# Don't actually build.
+build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,21 +1,12 @@
-# Test against the latest version of this Node.js version
 environment:
   nodejs_version: "7"
-
-# Install scripts. (runs after repo cloning)
 install:
-  # Get the latest stable version of Node.js or io.js
   - ps: Install-Product node $env:nodejs_version
-  # install modules
+  - npm install -g yarn mocha
   - npm install
-
-# Post-install test scripts.
 test_script:
-  # Output useful info for debugging.
   - node --version
   - npm --version
-  # run tests
+  - yarn -V
   - npm test
-
-# Don't actually build.
 build: off

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "adonis-fold": "^3.0.3",
-    "standard": "^9.0.0"
+    "standard": "^10.0.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "fs-extra": "^1.0.0",
     "pify": "^2.3.0",
     "semver": "^5.3.0",
-    "which": "^1.2.12"
+    "which": "^1.2.14"
   },
   "devDependencies": {
     "adonis-fold": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,11 @@
     "adonis": "src/index.js"
   },
   "scripts": {
-    "lint": "standard"
+    "test": "npm run withNpm && npm run clean && npm run withYarn && npm run clean",
+    "lint": "standard",
+    "withNpm": "node src/index.js new yardstick --npm",
+    "withYarn": "node src/index.js new yardstick --yarn",
+    "clean": "rm -rf yardstick"
   },
   "dependencies": {
     "adonis-ace": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,20 @@
   "name": "adonis-cli",
   "version": "2.1.9",
   "description": "Scaffold new adonis application",
+  "standard": {
+    "global": [
+      "afterEach",
+      "context",
+      "describe",
+      "it",
+      "use"
+    ]
+  },
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
+  },
   "keywords": [
     "adonis",
     "adonisjs",
@@ -10,7 +24,8 @@
   ],
   "author": "Harminder Virk <virk@adonisjs.com>",
   "contributors": [
-    "Romain Lanz <romain.lanz@slynova.ch>"
+    "Romain Lanz <romain.lanz@slynova.ch>",
+    "Abraham Aondowase Yusuf <aaondowasey@gmail.com>"
   ],
   "license": "MIT",
   "main": "src/index.js",
@@ -18,11 +33,8 @@
     "adonis": "src/index.js"
   },
   "scripts": {
-    "test": "npm run withNpm && npm run clean && npm run withYarn && npm run clean",
-    "lint": "standard",
-    "withNpm": "node src/index.js new yardstick --npm",
-    "withYarn": "node src/index.js new yardstick --yarn",
-    "clean": "rm -rf yardstick"
+    "test": "npm run lint && FORCE_COLOR=true mocha ./tests/Commands/New.js",
+    "lint": "standard"
   },
   "dependencies": {
     "adonis-ace": "^3.0.5",
@@ -35,6 +47,9 @@
   },
   "devDependencies": {
     "adonis-fold": "^3.0.3",
+    "chai": "^4.0.0",
+    "cz-conventional-changelog": "^2.0.0",
+    "mocha": "^3.4.2",
     "standard": "^10.0.0"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "adonis-ace": "^3.0.5",
     "adonis-fold": "^3.0.3",
     "cli-spinner": "^0.2.5",
-    "fs-extra": "^1.0.0",
+    "fs-extra": "^2.1.2",
     "pify": "^2.3.0",
     "semver": "^5.3.0",
     "which": "^1.2.14"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "adonis": "src/index.js"
   },
   "scripts": {
-    "test": "npm run lint && FORCE_COLOR=true mocha ./tests/Commands/New.js",
+    "test": "npm run lint && mocha ./tests/Commands/New.js",
     "lint": "standard"
   },
   "dependencies": {

--- a/src/Commands/Base.js
+++ b/src/Commands/Base.js
@@ -43,8 +43,16 @@ class Base extends Command {
    */
   * _checkRequirements () {
     const nodeVersion = process.version
-    const npmVersion = yield pify(exec)('npm -v')
+    let npmVersion
     let error = false
+
+    // retrieve npm version.
+    pify(exec)('npm -v').then(version => {
+      npmVersion = version
+    }).catch(err => {
+      // set npmVersion to empty string if npm is not installed
+      npmVersion = ''
+    })
 
     if (!semver.satisfies(nodeVersion, '>=4.0.0')) {
       this.error(`${this.icon('error')} Your current Node.js version doesn't match AdonisJs requirements.`)

--- a/src/Commands/Base.js
+++ b/src/Commands/Base.js
@@ -48,7 +48,7 @@ class Base extends Command {
 
     // retrieve npm version.
     try {
-      npmVersion = pify(exec)('npm -v')
+      npmVersion = yield pify(exec)('npm -v')
     } catch (e) {
       // set npmVersion to empty string if npm is not installed
       npmVersion = ''

--- a/src/Commands/Base.js
+++ b/src/Commands/Base.js
@@ -21,7 +21,6 @@ const Spinner = require('cli-spinner').Spinner
  * @submodule cli
  */
 class Base extends Command {
-
   /**
    * Constructor.
    *
@@ -125,10 +124,9 @@ class Base extends Command {
    */
   _dumpAsciiLogo () {
     this.log(
-      this.colors.green("    _       _             _         _     \n   \/ \\   __| | ___  _ __ (_)___    | |___ \n  \/ _ \\ \/ _` |\/ _ \\| '_ \\| \/ __|_  | \/ __|\n \/ ___ \\ (_| | (_) | | | | \\__ \\ |_| \\__ \\\n\/_\/   \\_\\__,_|\\___\/|_| |_|_|___\/\\___\/|___\/\n")
+      this.colors.green("    _       _             _         _     \n   / \\   __| | ___  _ __ (_)___    | |___ \n  / _ \\ / _` |/ _ \\| '_ \\| / __|_  | / __|\n / ___ \\ (_| | (_) | | | | \\__ \\ |_| \\__ \\\n/_/   \\_\\__,_|\\___/|_| |_|_|___/\\___/|___/\n")
     )
   }
-
 }
 
 module.exports = Base

--- a/src/Commands/Base.js
+++ b/src/Commands/Base.js
@@ -40,18 +40,9 @@ class Base extends Command {
    * @method _checkRequirements
    * @return {void}
    */
-  * _checkRequirements () {
+  * _checkRequirements (yarnToolRequested) {
     const nodeVersion = process.version
-    let npmVersion
     let error = false
-
-    // retrieve npm version.
-    try {
-      npmVersion = yield pify(exec)('npm -v')
-    } catch (e) {
-      // set npmVersion to empty string if npm is not installed
-      npmVersion = ''
-    }
 
     if (!semver.satisfies(nodeVersion, '>=4.0.0')) {
       this.error(`${this.icon('error')} Your current Node.js version doesn't match AdonisJs requirements.`)
@@ -59,17 +50,34 @@ class Base extends Command {
       error = true
     }
 
-    if (!semver.satisfies(npmVersion, '>=3.0.0')) {
-      this.error(`${this.icon('error')} Your current npm version doesn't match AdonisJs requirements.`)
-      this.error(`${this.icon('info')} Please update your npm installation to >= 3.0.0 before continue.`)
-      error = true
+    if (yarnToolRequested) {
+      if (!this._hasYarnInstalled()) {
+        this.error(`${this.icon('error')} Yarn dependency tool is not installed.`)
+        this.error(`${this.icon('info')} Please install yarn before continue.`)
+        error = true
+      }
+    } else {
+      let npmVersion
+      // retrieve npm version.
+      try {
+        npmVersion = yield pify(exec)('npm -v')
+      } catch (e) {
+        // set npmVersion to empty string if npm is not installed
+        npmVersion = ''
+      }
+
+      if (!semver.satisfies(npmVersion, '>=3.0.0')) {
+        this.error(`${this.icon('error')} Your current npm version doesn't match AdonisJs requirements.`)
+        this.error(`${this.icon('info')} Please update your npm installation to >= 3.0.0 before continue.`)
+        error = true
+      }
     }
 
     if (error) {
       process.exit(0)
     }
 
-    this.success(`${this.icon('success')} Your current Node.js & npm version match the AdonisJs requirements!`)
+    this.success(`${this.icon('success')} Your current Node.js & ${yarnToolRequested ? 'yarn' : 'npm'} version match the AdonisJs requirements!`)
   }
 
   /**

--- a/src/Commands/Base.js
+++ b/src/Commands/Base.js
@@ -47,12 +47,12 @@ class Base extends Command {
     let error = false
 
     // retrieve npm version.
-    pify(exec)('npm -v').then(version => {
-      npmVersion = version
-    }).catch(err => {
+    try {
+      npmVersion = pify(exec)('npm -v')
+    } catch (e) {
       // set npmVersion to empty string if npm is not installed
       npmVersion = ''
-    })
+    }
 
     if (!semver.satisfies(nodeVersion, '>=4.0.0')) {
       this.error(`${this.icon('error')} Your current Node.js version doesn't match AdonisJs requirements.`)

--- a/src/Commands/New.js
+++ b/src/Commands/New.js
@@ -79,7 +79,7 @@ class New extends BaseCommand {
     }
 
     this._dumpAsciiLogo()
-    yield this._checkRequirements()
+    yield this._checkRequirements(options.yarn)
     yield this._verifyApplicationDoesntExist()
     yield this._cloneRepository()
 

--- a/src/Commands/New.js
+++ b/src/Commands/New.js
@@ -21,7 +21,6 @@ const exec = require('child_process').exec
  * @extends Base
  */
 class New extends BaseCommand {
-
   /**
    * Returns the signature of the command.
    *
@@ -29,15 +28,15 @@ class New extends BaseCommand {
    * @property signature
    * @return {string}
    */
-get signature () {
-  return `new {name:Name of your application}
+  get signature () {
+    return `new {name:Name of your application}
     {--skip-install?:Skip the installation process}
     {--branch?=@value:Branch to be used}
     {--blueprint?=@value:Repository to be used}
     {--yarn?:Use yarn to install dependencies}
     {--npm?:Use npm to install dependencies}
   `
-}
+  }
 
   /**
    * Returns the description of the command.
@@ -121,9 +120,9 @@ get signature () {
       process.exit(0)
     } catch (e) {
       if (e.code !== 'ENOENT') {
-          this.error(`${this.icon('error')} An error occured while trying to access "${this.applicationPath}" directory`)
-          this.error(e.message)
-          process.exit(0)
+        this.error(`${this.icon('error')} An error occured while trying to access "${this.applicationPath}" directory`)
+        this.error(e.message)
+        process.exit(0)
       }
     }
   }
@@ -249,7 +248,6 @@ get signature () {
       this.error(e.message)
     }
   }
-
 }
 
 module.exports = New

--- a/tests/Commands/New.js
+++ b/tests/Commands/New.js
@@ -1,0 +1,55 @@
+'use strict'
+
+/**
+ * adonis-cli
+ * @license MIT
+ * @copyright Adonis - Harminder Virk <virk@adonisjs.com>
+*/
+
+const expect = require('chai').expect
+const exec = require('child_process').exec
+const fs = require('fs-extra')
+const path = require('path')
+const pify = require('pify')
+
+const script = path.join(__dirname, '../../src/index.js')
+const projectDir = path.join(process.cwd(), 'yardstick')
+const asyncTimeoutMilis = 1 * 60 * 1000 // 1 minutes
+
+describe('`adonis new` command', function () {
+  this.timeout(asyncTimeoutMilis)
+
+  afterEach(function (done) {
+    fs.exists(projectDir, exists => {
+      if (exists) {
+        fs.remove(projectDir, done)
+      }
+    })
+  })
+  context('when invoked with `--yarn` flag', function () {
+    it('should create project and install dependencies with yarn', function (done) {
+      let command = `node ${script} new yardstick --yarn`
+
+      pify(exec)(command).then(() => {
+        let yarnLockFile = path.join(projectDir, 'yarn.lock')
+        expect(fs.existsSync(yarnLockFile)).to.equal(true)
+        done()
+      }).catch(error => {
+        done(error)
+      })
+    })
+  })
+  context('when invoked with `--npm` flag', function () {
+    it('should create project and install dependencies with npm', function (done) {
+      let command = `node ${script} new yardstick --npm`
+
+      pify(exec)(command).then(() => {
+        let nodeModulesDir = path.join(projectDir, 'node_modules')
+        expect(fs.existsSync(nodeModulesDir)).to.equal(true)
+        done()
+      }).catch(error => {
+        done(error)
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR solves issue #39 . Instead of terminating with an error it gracefully terminates when npm is not installed.

The PR also added tests and travis/appveyor build scripts