### PR TITLE
Allow white space in paths

### DIFF
--- a/src/Commands/New/steps/clone.js
+++ b/src/Commands/New/steps/clone.js
@@ -44,7 +44,7 @@ module.exports = async function (blueprint, appPath, chalk, icon, branch = null)
   }
 
   // complete the clone command
-  cloneCommand = `${cloneCommand} https://github.com/${blueprint}.git ${appPath}`
+  cloneCommand = `${cloneCommand} https://github.com/${blueprint}.git "${appPath}"`
 
   try {
     await pify(exec)(cloneCommand)


### PR DESCRIPTION
If there is white space for the appPath, command line with think that it is additional arguments. Adding quotes around the appPath for a single argument.