### PR TITLE
Updated Commands/Serve/index.js

### DIFF
--- a/src/Commands/Serve/index.js
+++ b/src/Commands/Serve/index.js
@@ -150,7 +150,7 @@ Debbuger: ${debug ? 'Visit ' + this.chalk.yellow('chrome://inspect') + ' to open
         js: debug ? 'node --inspect' : 'node'
       },
       ext: ext,
-      ignore: ['tmp/*'],
+      ignore: ['tmp/*', 'public/*'],
       watch: watchDirs
     })
 


### PR DESCRIPTION
Added `/public` folder to ignored in `nodemon`.
There is a filter by extension in code, so each time a `.js` file in `/public` is changed, the server restarts. I don't think that it should in that case, as soon as in `/public` folder files are being served only for client.