### PR TITLE
Trait generator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@adonisjs/cli",
-  "version": "3.0.14",
+  "version": "3.0.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@adonisjs/ace": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@adonisjs/ace/-/ace-4.0.6.tgz",
-      "integrity": "sha512-KFe1i2RAVSxz9k6LGaMZVGyIuCcONu5BE0OkQyRzTYwvrP+6uQdjWY+9owkaBTHb3VnjyT3jknMFP5EBRYiVoA==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@adonisjs/ace/-/ace-4.0.7.tgz",
+      "integrity": "sha512-SO2FEUrf7BJPbnFPLzXQllEP7VDPxp7+eUS4ci0oHMHiIQyLrvSd9hUq+t59pzYc4cFK9sjb8Kg2wrDiShdlig==",
       "requires": {
         "cli-table": "0.3.1",
         "commander": "2.11.0",
@@ -2278,13 +2278,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -2292,6 +2285,13 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -5799,14 +5799,6 @@
         "duplexer": "0.1.1"
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -5814,6 +5806,14 @@
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/src/Commands/Make/Base.js
+++ b/src/Commands/Make/Base.js
@@ -18,6 +18,7 @@ const options = {
     httpControllers: 'Controllers/Http',
     wsControllers: 'Controllers/Ws',
     models: 'Models',
+    traits: 'Models/Traits',
     hooks: 'Models/Hooks',
     listeners: 'Listeners',
     exceptions: 'Exceptions',

--- a/src/Commands/Make/Trait.js
+++ b/src/Commands/Make/Trait.js
@@ -61,13 +61,10 @@ class MakeTrait extends BaseCommand {
         `Register your ${name} trait with any model as follows`,
         '',
         `
-const Model = use('Model')
-const ${name} = use('App/Models/Traits/${name}')
-
-class {{name}} extends Model {
-  static boot() {
+class User extends Model {
+  static boot () {
     super.boot()
-    this.addTrait(${name}())
+    this.addTrait('App/Models/Traits/${name}')
   }
 }
         `

--- a/src/Commands/Make/Trait.js
+++ b/src/Commands/Make/Trait.js
@@ -1,0 +1,83 @@
+'use strict'
+
+/*
+ * adonis-cli
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+*/
+
+const BaseCommand = require('./Base')
+
+/**
+ * Make a new lucid trait
+ *
+ * @class MakeTrait
+ * @constructor
+ */
+class MakeTrait extends BaseCommand {
+  /**
+   * The command signature
+   *
+   * @method signature
+   *
+   * @return {String}
+   */
+  static get signature () {
+    return `
+    make:trait
+    { name: Name of the trait }
+    `
+  }
+
+  /**
+   * The command description
+   *
+   * @method description
+   *
+   * @return {String}
+   */
+  static get description () {
+    return 'Make a new lucid trait'
+  }
+
+  /**
+   * Handle method executed by ace
+   *
+   * @method handle
+   *
+   * @param  {String} options.name
+   *
+   * @return {void}
+   */
+  async handle ({ name }) {
+    try {
+      await this.ensureInProjectRoot()
+      await this.generateBlueprint('trait', name, {})
+
+      const lines = [
+        `Register your ${name} trait with any model as follows`,
+        '',
+        `
+const Model = use('Model')
+const ${name} = use('App/Models/Traits/${name}')
+
+class {{name}} extends Model {
+  static boot() {
+    self.boot()
+    this.addTrait(${name}())
+  }
+}
+        `
+      ]
+
+      this.printInstructions(lines)
+    } catch ({ message }) {
+      this.error(message)
+    }
+  }
+}
+
+module.exports = MakeTrait

--- a/src/Commands/Make/Trait.js
+++ b/src/Commands/Make/Trait.js
@@ -66,7 +66,7 @@ const ${name} = use('App/Models/Traits/${name}')
 
 class {{name}} extends Model {
   static boot() {
-    self.boot()
+    super.boot()
     this.addTrait(${name}())
   }
 }

--- a/src/Commands/index.js
+++ b/src/Commands/index.js
@@ -21,6 +21,7 @@ module.exports = {
   'key:generate': require('./KeyGenerate'),
   'make:controller': require('./Make/Controller'),
   'make:model': require('./Make/Model'),
+  'make:trait': require('./Make/Trait'),
   'make:view': require('./Make/View'),
   'make:middleware': require('./Make/Middleware'),
   'make:command': require('./Make/Command'),

--- a/src/Generators/index.js
+++ b/src/Generators/index.js
@@ -112,6 +112,54 @@ generators.model = {
   }
 }
 
+generators.trait = {
+  /**
+   * Returns data object for the trait
+   * template file
+   *
+   * @method getData
+   *
+   * @param  {String} name
+   *
+   * @return {Object}
+   */
+  getData (name) {
+    return {
+      name: this.getFileName(name)
+    }
+  },
+
+  /**
+   * Returns the trait file name
+   *
+   * @method getFileName
+   *
+   * @param  {String}    name
+   *
+   * @return {String}
+   */
+  getFileName (name, appPath) {
+    name = name.replace(/trait/ig, '')
+    return `${pluralize.singular(_.upperFirst(_.camelCase(name)))}`
+  },
+
+  /**
+   * Returns file path to the trait file
+   *
+   * @method getFilePath
+   *
+   * @param  {String}    name
+   * @param  {Object}    options
+   *
+   * @return {String}
+   */
+  getFilePath (name, options) {
+    const baseName = path.basename(name)
+    const normalizedName = name.replace(baseName, this.getFileName(baseName))
+    return path.join(options.appRoot, options.appDir, options.dirs.traits, normalizedName) + '.js'
+  }
+}
+
 generators.middleware = {
   /**
    * Returns data for the middleware template

--- a/src/Generators/templates/trait.mustache
+++ b/src/Generators/templates/trait.mustache
@@ -1,0 +1,8 @@
+'use strict'
+
+const Model = use('Model')
+
+module.exports = (config = {}) => {
+  return (Model) => {
+  }
+}

--- a/src/Generators/templates/trait.mustache
+++ b/src/Generators/templates/trait.mustache
@@ -1,8 +1,10 @@
 'use strict'
+const _ = require('lodash')
 
 class {{name}} {
-  register (Model) {
-
+  register (Model, customOptions) {
+    const defaultOptions = {}
+    const options = _.extend({}, defaultOptions, customOptions)
   }
 }
 

--- a/src/Generators/templates/trait.mustache
+++ b/src/Generators/templates/trait.mustache
@@ -15,7 +15,7 @@ const {{name}} = use('App/Models/Traits/{{name}}')
 
 class User extends Model {
   static boot() {
-    self.boot()
+    super.boot()
     this.addTrait({{name}}())
   }
 }

--- a/src/Generators/templates/trait.mustache
+++ b/src/Generators/templates/trait.mustache
@@ -2,7 +2,34 @@
 
 const Model = use('Model')
 
-module.exports = (config = {}) => {
+/*********************
+{{name}} Trait
+**********************
+
+See full documentation at http://dev.adonisjs.com/docs/4.0/traits
+
+ATTACHING TO A MODEL
+--------------------
+
+const {{name}} = use('App/Models/Traits/{{name}}')
+
+class User extends Model {
+  static boot() {
+    self.boot()
+    this.addTrait({{name}}())
+  }
+}
+
+PASSING CONFIGURATION VALUES
+----------------------------
+
+{{name}} can change its behavior via configuration. Simply pass a configuration array when attaching the trait.
+
+this.addTrait({{name}}({greeting: 'Hello'}))
+
+*/
+
+module.exports = (settings = {}) => {
   return (Model) => {
   }
 }

--- a/src/Generators/templates/trait.mustache
+++ b/src/Generators/templates/trait.mustache
@@ -1,35 +1,9 @@
 'use strict'
 
-const Model = use('Model')
+class {{name}} {
+  register (Model) {
 
-/*********************
-{{name}} Trait
-**********************
-
-See full documentation at http://dev.adonisjs.com/docs/4.0/traits
-
-ATTACHING TO A MODEL
---------------------
-
-const {{name}} = use('App/Models/Traits/{{name}}')
-
-class User extends Model {
-  static boot() {
-    super.boot()
-    this.addTrait({{name}}())
   }
 }
 
-PASSING CONFIGURATION VALUES
-----------------------------
-
-{{name}} can change its behavior via configuration. Simply pass a configuration array when attaching the trait.
-
-this.addTrait({{name}}({greeting: 'Hello'}))
-
-*/
-
-module.exports = (settings = {}) => {
-  return (Model) => {
-  }
-}
+module.exports = {{name}}

--- a/test/generators.spec.js
+++ b/test/generators.spec.js
@@ -19,6 +19,7 @@ const OPTS = {
     httpControllers: 'Controllers/Http',
     wsControllers: 'Controllers/Ws',
     models: 'Models',
+    traits: 'Models/Traits',
     hooks: 'Models/Hooks',
     listeners: 'Listeners',
     exceptions: 'Exceptions',
@@ -69,6 +70,26 @@ test.group('Generators', () => {
   test('get data for model', (assert) => {
     const data = generators.model.getData('UsersModel', {})
     assert.deepEqual(data, { name: 'User' })
+  })
+
+  test('get path to the trait file', (assert) => {
+    const filePath = generators.trait.getFilePath('Attachable', OPTS)
+    assert.equal(filePath, path.join(__dirname, 'app/Models/Traits', 'Attachable.js'))
+  })
+
+  test('singularize trait name', (assert) => {
+    const filePath = generators.trait.getFilePath('Attachables', OPTS)
+    assert.equal(filePath, path.join(__dirname, 'app/Models/Traits', 'Attachable.js'))
+  })
+
+  test('normalize trait name', (assert) => {
+    const filePath = generators.trait.getFilePath('AttachablesTrait', OPTS)
+    assert.equal(filePath, path.join(__dirname, 'app/Models/Traits', 'Attachable.js'))
+  })
+
+  test('get data for trait', (assert) => {
+    const data = generators.trait.getData('AttachablesTrait', {})
+    assert.deepEqual(data, { name: 'Attachable' })
   })
 
   test('get path to the middleware file', (assert) => {


### PR DESCRIPTION
@thetutlage Please have a look at how I did the `module.exports` to provide for configurable settings. I needed a way to pass settings into my traits.

```javascript
const MyTrait = use('App/Models/Traits/MyTrait')

class User {
  static boot() {
    super.boot()
    this.addTrait(MyTrait({...}))
  }
}
```

Is there a better architecture?

Maybe `this.addTrait(new MyTrait({...}))` could also work, but I the current solution doesn't require any Lucid changes.