### PR TITLE
Allow `adonis serve --dev` to run in background

### DIFF
--- a/src/Commands/Serve/index.js
+++ b/src/Commands/Serve/index.js
@@ -188,7 +188,8 @@ Debugger: ${debug ? 'Visit ' + this.chalk.yellow('chrome://inspect') + ' to open
       ext: ext,
       legacyWatch: !!polling,
       ignore: ['tmp/*', 'public/*'],
-      watch: watchDirs
+      watch: watchDirs,
+      stdin: false
     })
 
     this.started(dev, debug)


### PR DESCRIPTION
Without this, you get `Stopped (tty input)` when trying to background `adonis serve --dev`