### PR TITLE
Added the ability to set table and rows flags

### DIFF
--- a/src/Commands/Make/Migration.js
+++ b/src/Commands/Make/Migration.js
@@ -29,6 +29,8 @@ class MakeMigration extends BaseCommand {
     return `
     make:migration
     { name: Name of migration file, current timestamp will be prepended to the name }
+    { --table?=@value: Table to create the migration on }
+    { --rows?=@value: Rows to add to the table }
     { --action?=@value : Choose an action to \`create\` or \`select\` a table }
     `
   }
@@ -81,11 +83,11 @@ class MakeMigration extends BaseCommand {
    * @return {void|String} - Returns abs path to created file when command
    *                         is not executed by ace.
    */
-  async handle ({ name }, { action }) {
+  async handle ({ name }, { table, action, rows }) {
     try {
       await this.ensureInProjectRoot()
       const actionType = await this._getActionType(action)
-      await this.generateBlueprint('schema', name, { action: actionType })
+      await this.generateBlueprint('schema', name, { table: table, action: actionType, rows: rows })
     } catch ({ message }) {
       this.error(message)
     }

--- a/src/Generators/templates/schema.mustache
+++ b/src/Generators/templates/schema.mustache
@@ -2,11 +2,14 @@
 
 const Schema = use('Schema')
 
-class {{ name }} extends Schema {
+class {{ className }} extends Schema {
   {{#create}}
   up () {
     this.create('{{ table }}', (table) => {
       table.increments()
+      {{#rows}}
+      {{{ . }}}
+      {{/rows}}
       table.timestamps()
     })
   }
@@ -19,6 +22,9 @@ class {{ name }} extends Schema {
   up () {
     this.table('{{ table }}', (table) => {
       // alter table
+      {{#rows}}
+      {{{ . }}}
+      {{/rows}}
     })
   }
 
@@ -30,4 +36,4 @@ class {{ name }} extends Schema {
   {{/create}}
 }
 
-module.exports = {{ name }}
+module.exports = {{ className }}

--- a/test/generators.spec.js
+++ b/test/generators.spec.js
@@ -184,17 +184,28 @@ test.group('Generators', () => {
 
   test('get data for schema', (assert) => {
     const data = generators.schema.getData('users', {})
-    assert.deepEqual(data, { create: false, table: 'users', name: 'UsersSchema' })
+    assert.deepEqual(data, { create: false, table: 'users', className: 'UsersSchema', rows: [] })
   })
 
   test('pluralize table name', (assert) => {
     const data = generators.schema.getData('user', {})
-    assert.deepEqual(data, { create: false, table: 'users', name: 'UserSchema' })
+    assert.deepEqual(data, { create: false, table: 'users', className: 'UserSchema', rows: [] })
   })
 
   test('snake case table name', (assert) => {
     const data = generators.schema.getData('UserProfile', {})
-    assert.deepEqual(data, { create: false, table: 'user_profiles', name: 'UserProfileSchema' })
+    assert.deepEqual(data, { create: false, table: 'user_profiles', className: 'UserProfileSchema', rows: [] })
+  })
+
+  test('schema rows', (assert) => {
+    const data = generators.schema.getData('users', { rows: 'name:string:required,email:string:required' })
+    assert.deepEqual(data, { create: false,
+      table: 'users',
+      className: 'UsersSchema',
+      rows: [
+        'table.string(\'name\').notNullable()',
+        'table.string(\'email\').notNullable()'
+      ] })
   })
 
   test('get path to the listener file', (assert) => {


### PR DESCRIPTION
Currently, generating migrations using the CLI isn't all that helpful as it uses the migration name as the table name. This PR fixes that by adding a `--table` flag which will set the table name. If it's not defined it will revert to it's default behaviour of using the migration name. This feature was requested by @cannap in gitter.

This PR also adds an additional flag, `--rows`, which accepts a comma separated list of rows to be added and their properties. The structure should look something like this

```bash
--rows rowName:rowType:[optional additional attributes]
```

The attributes that have been added are **required**, **nullable**, **index**, **primary**, and **unique**. I'd like to find a way to do **default** as well, but I couldn't think of a good way to format it.