### PR TITLE
fix(serve): add root directory to ignore files nodemon

### DIFF
--- a/src/Commands/Serve/index.js
+++ b/src/Commands/Serve/index.js
@@ -187,7 +187,10 @@ Debugger: ${debug ? 'Visit ' + this.chalk.yellow('chrome://inspect') + ' to open
       },
       ext: ext,
       legacyWatch: !!polling,
-      ignore: ['tmp/*', 'public/*'],
+      ignore: [
+        process.cwd() + '/tmp/*',
+        process.cwd() + '/public/*'
+      ],
       watch: watchDirs,
       stdin: false
     })


### PR DESCRIPTION

Problem when installing adonisjs in / tmp / or / public / directory, 
nodemon does not detect modified files.

Fixbug by adding the root directory to nodemon ignore files