### PR TITLE
Fixed directory name reflecting in class name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@adonisjs/cli",
-  "version": "3.0.16",
+  "version": "3.0.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/Commands/Make/Base.js
+++ b/src/Commands/Make/Base.js
@@ -68,7 +68,8 @@ class MakeBase extends Command {
     const templateFile = path.join(__dirname, '../../Generators/templates', `${templateFor}.mustache`)
 
     const filePath = generators[templateFor].getFilePath(name, options)
-    const data = generators[templateFor].getData(name, flags)
+    const baseName = path.basename(name)
+    const data = generators[templateFor].getData(baseName, flags)
 
     const templateContents = await this.readFile(templateFile, 'utf-8')
     await this.generateFile(filePath, templateContents, data)

--- a/src/Commands/Make/Base.js
+++ b/src/Commands/Make/Base.js
@@ -68,8 +68,7 @@ class MakeBase extends Command {
     const templateFile = path.join(__dirname, '../../Generators/templates', `${templateFor}.mustache`)
 
     const filePath = generators[templateFor].getFilePath(name, options)
-    const baseName = path.basename(name)
-    const data = generators[templateFor].getData(baseName, flags)
+    const data = generators[templateFor].getData(path.basename(name), flags)
 
     const templateContents = await this.readFile(templateFile, 'utf-8')
     await this.generateFile(filePath, templateContents, data)


### PR DESCRIPTION
Fixed directory name reflecting in the class name when the `make` command is used.

For example:

**Before**

```bash
adonis make:controller Sample/Tests --type=http
```

The above will create `app/Controllers/Http/Sample/TestController.js` but the class name will be `SampleTestController`

With this PR, the command will work as expected. That is, `app/Controllers/Http/Sample/TestController.js` with the class name of `TestController`.
