### PR TITLE
fix(commands): support prereleases of Node.js

### DIFF
--- a/src/Services/check-node-version.js
+++ b/src/Services/check-node-version.js
@@ -11,6 +11,7 @@
 
 const semver = require('semver')
 const requiredNodeVersion = '>=8.0.0'
+const requiredNodeVersionNumber = 8
 const requiredNpmVersion = '>=3.0.0'
 
 /**
@@ -32,9 +33,11 @@ module.exports = async function (stepsCounter) {
 
   /**
    * Verify Node.js version
+   * Uses `semver.parse` instead of `semver.satistfies` to support prereleases
+   * of Node.js
    */
   const nodeVersion = process.version
-  if (!semver.satisfies(nodeVersion, requiredNodeVersion)) {
+  if (semver.parse(nodeVersion).major < requiredNodeVersionNumber) {
     step.error('Unsupported Node.js version', 'x')
     throw new Error(`Unsatisfied Node.js version ${nodeVersion}. Please update Node.js to ${requiredNodeVersion} before you continue`)
   }


### PR DESCRIPTION
Prereleases of Node.js such as nightly or canary releases have a
prerelease tag. Their version strings are valid semver but
semver.satisfies does not return true when compared to a regular version
number.

Refs: https://www.npmjs.com/package/semver#prerelease-tags

<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-cli/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I wanted to give Adonis a try, but got blocked when I tried to create my first project:

```
adonis new adonis-playground
   ERROR  Unsatisfied Node.js version v11.0.0-v8-canary20180727953d5c257c. Please update Node.js to >=8.0.0 before you continue
```