### PR TITLE
feat(serve): add ignore options

### DIFF
--- a/src/Commands/Serve/index.js
+++ b/src/Commands/Serve/index.js
@@ -165,19 +165,6 @@ class Serve extends Command {
     }
 
     const nodemon = require('nodemon')
-    const foldersToIgnore = [
-      process.cwd() + '/tmp/*',
-      process.cwd() + '/public/*',
-      process.cwd() + '/resources/*'
-    ]
-
-    if (ignore) {
-      const customFoldersToIgnore = ignore.split(',').map(folder => (
-        process.cwd() + `/${folder}/*`
-      ))
-
-      foldersToIgnore.concat(customFoldersToIgnore)
-    }
 
     nodemon({
       script: appFile,
@@ -186,7 +173,7 @@ class Serve extends Command {
       },
       ext: ext,
       legacyWatch: !!polling,
-      ignore: foldersToIgnore,
+      ignore: ['/tmp/*', '/resources/*', '/public/*'].concat(ignore || []).map((folder) => `${process.cwd()}/${folder}`),
       watch: watchDirs,
       stdin: false
     })

--- a/src/Commands/Serve/index.js
+++ b/src/Commands/Serve/index.js
@@ -32,6 +32,7 @@ class Serve extends Command {
     { --dev : Start development server }
     { -w, --watch=@value : A custom set of only files to watch },
     { -e, --ext=@value : A custom set of extensions to watch },
+    { -i, --ignore=@value : A custom set of folders to ignore watching },
     { -p, --polling : Use polling to find file changes. Also required when using Docker }
     { --debug?=@value: Start server in debug mode }
     `
@@ -122,7 +123,7 @@ class Serve extends Command {
    *
    * @return {void}
    */
-  async handle (args, { dev, watch, debug, polling, ext }) {
+  async handle (args, { dev, watch, debug, ignore, polling, ext }) {
     const acePath = path.join(process.cwd(), 'ace')
     const appFile = path.join(process.cwd(), 'server.js')
     const exists = await this.pathExists(acePath)
@@ -164,6 +165,19 @@ class Serve extends Command {
     }
 
     const nodemon = require('nodemon')
+    const foldersToIgnore = [
+      process.cwd() + '/tmp/*',
+      process.cwd() + '/public/*',
+      process.cwd() + '/resources/*',
+    ]
+
+    if (ignore) {
+      const customFoldersToIgnore = ignore.split(',').map(folder => (
+        process.cwd() + `/${folder}/*`
+      ))
+
+      foldersToIgnore.concat(customFoldersToIgnore)
+    }
 
     nodemon({
       script: appFile,
@@ -172,11 +186,7 @@ class Serve extends Command {
       },
       ext: ext,
       legacyWatch: !!polling,
-      ignore: [
-        process.cwd() + '/tmp/*',
-        process.cwd() + '/public/*',
-        process.cwd() + '/resources/*'
-      ],
+      ignore: foldersToIgnore,
       watch: watchDirs,
       stdin: false
     })

--- a/src/Commands/Serve/index.js
+++ b/src/Commands/Serve/index.js
@@ -168,7 +168,7 @@ class Serve extends Command {
     const foldersToIgnore = [
       process.cwd() + '/tmp/*',
       process.cwd() + '/public/*',
-      process.cwd() + '/resources/*',
+      process.cwd() + '/resources/*'
     ]
 
     if (ignore) {

--- a/src/Commands/Serve/index.js
+++ b/src/Commands/Serve/index.js
@@ -174,7 +174,8 @@ class Serve extends Command {
       legacyWatch: !!polling,
       ignore: [
         process.cwd() + '/tmp/*',
-        process.cwd() + '/public/*'
+        process.cwd() + '/public/*',
+        process.cwd() + '/resources/*'
       ],
       watch: watchDirs,
       stdin: false


### PR DESCRIPTION
Hey 👋

This PR add two things.

1. Per default we don't watch the folder `resources`, this folder should only contain frontend stuff or compiled assets. There's no need to reboot the whole server when they change.

2. It's adding the `--ignore` flag to the `serve` command. It let us set custom path to be ignored by `nodemon`.

**How to use it?**

```bash
> adonis serve --ignore="nuxt,myCustom,next"
```

This command will ignore the default ignored folder + `nuxt`, `myCustom` and `next`.