### PR TITLE
fix(deps): upgrade `nodemon`

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "is-git-url": "^1.0.0",
     "lodash": "^4.17.11",
     "marked": "^0.5.1",
-    "nodemon": "^1.18.4",
+    "nodemon": "^1.18.7",
     "opn": "^5.4.0",
     "pluralize": "^7.0.0",
     "randomstring": "^1.1.5",


### PR DESCRIPTION
The `nodemon` utility was not direclty dependent of `event-stream`
but it was still impacted by the `event-stream` hack.

See: https://github.com/dominictarr/event-stream/issues/116