### PR TITLE
fix: copy lock files to build and use npm ci

### DIFF
--- a/src/Commands/Build.ts
+++ b/src/Commands/Build.ts
@@ -48,10 +48,15 @@ export default class Build extends BaseCommand {
     const compiler = new Compiler(this, this.projectRoot, rcContents)
 
     /**
-     * Pushing `package.json` to `copyToBuild` array, so that later we can run `npm install`
+     * Pushing `package.json` and lock file to `copyToBuild` array, so that later we can run `npm install`
      * inside the build directory
      */
     rcContents.copyToBuild.push('package.json')
+    if (this.yarn) {
+      rcContents.copyToBuild.push('yarn.lock')
+    } else {
+      rcContents.copyToBuild.push('package-lock.json')
+    }
     await compiler.buildForProduction(this.yarn ? 'yarn' : 'npm')
   }
 }

--- a/src/Services/Installer.ts
+++ b/src/Services/Installer.ts
@@ -24,7 +24,7 @@ export class Installer {
    * Install project dependencies using npm
    */
   private _npmInstall () {
-    const args = this._production ? ['install', '--production'] : ['install']
+    const args = this._production ? ['ci', '--production'] : ['install']
     execa('npm', args, {
       buffer: false,
       stdio: 'inherit',


### PR DESCRIPTION
- Lock files ensure dependencies have the same versions in dev and prod
- npm ci is much faster than npm install in clean directories
