### PR TITLE
fix(Compiler): show delete log only on tracked file

### DIFF
--- a/src/Services/Compiler.ts
+++ b/src/Services/Compiler.ts
@@ -212,10 +212,9 @@ export class Compiler {
    * Handling static file removals
    */
   private async _handleFileRemoval (filePath: string, outDir: string, httpServer: HttpServer) {
-    fancyLogs.delete(filePath)
-
     if (this._rcWrapper.isReloadServerFile(filePath)) {
       await remove(join(outDir!, filePath))
+      fancyLogs.delete(filePath)
       httpServer.restart()
       return
     }
@@ -225,6 +224,7 @@ export class Compiler {
      */
     if (this._rcWrapper.isMetaFile(filePath)) {
       await remove(join(outDir!, filePath))
+      fancyLogs.delete(filePath)
     }
   }
 


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Currently the logger logs everytime we delete a file, even when the file shouldn't be tracked (i.e: `.git`).

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-cli/blob/develop/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
